### PR TITLE
[FIX] account_ux: After web_notify dependencies module now it's

### DIFF
--- a/account_ux/wizards/res_config_settings.py
+++ b/account_ux/wizards/res_config_settings.py
@@ -43,8 +43,8 @@ class ResConfigSettings(models.TransientModel):
             company_id=company_id)
 
         res.update({
-            'sale_tax_ids': [(6, 0, taxes_ids)],
-            'purchase_tax_ids': [(6, 0, supplier_taxes_ids)],
+            'sale_tax_ids': [(6, 0, taxes_ids or [])],
+            'purchase_tax_ids': [(6, 0, supplier_taxes_ids or [])],
         })
         return res
 


### PR DESCRIPTION
installed automatically, and since there cold be not any default taxes,
this is failing on res.config.settings execute trying to iterate over
None object

```python
for other, data in pycompat.izip(others, data_list)
File "/root/odoo-12.0/odoo/fields.py", line 2769, in create
rel_ids[record.id].update(act[2])
TypeError: 'NoneType' object is not iterable
```